### PR TITLE
RHN Pool Support

### DIFF
--- a/lib/puppet/provider/rhsm_pool/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_pool/subscription_manager.rb
@@ -1,0 +1,42 @@
+Puppet::Type.type(:rhsm_pool).provide(:subscription_manager) do
+  @doc = <<-EOS
+    This provider registers applies a specific subscription to the system.
+  EOS
+
+  confine :osfamily => :redhat
+  confine :feature => :json
+
+  commands :subscription_manager => "subscription-manager"
+
+  def create
+    subscription_manager('attach','--pool',@resource[:id])
+  end
+
+  def destroy
+    #subscription_manager('repos','--disable',@resource[:name])
+  end
+
+  def self.consumed_pools
+    debug(subscription_manager('list','--pool','--consumed').split("\n"))
+    subscription_manager('list','--pool','--consumed').split("\n")
+  end
+
+  def self.instances
+    consumed_pools.collect do |pool|
+      new(:name => pool, :ensure => :present )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+end

--- a/lib/puppet/type/rhsm_pool.rb
+++ b/lib/puppet/type/rhsm_pool.rb
@@ -2,12 +2,12 @@ require 'puppet/property/boolean'
 require 'puppet/type'
 
 Puppet::Type.newtype(:rhsm_pool) do
-  @doc = "Subscribe to a specific subscription pool"
+  @doc = ""
 
   ensurable
 
   newparam(:id, :namevar => true) do
-    desc "The ID of the subscription pool to attach to."
+    desc "The rhsm channel to subscribe to."
   end
 
 end

--- a/lib/puppet/type/rhsm_repo.rb
+++ b/lib/puppet/type/rhsm_repo.rb
@@ -1,13 +1,13 @@
 require 'puppet/property/boolean'
 require 'puppet/type'
 
-Puppet::Type.newtype(:rhsm_pool) do
-  @doc = "Subscribe to a specific subscription pool"
+Puppet::Type.newtype(:rhsm_repo) do
+  @doc = ""
 
   ensurable
 
-  newparam(:id, :namevar => true) do
-    desc "The ID of the subscription pool to attach to."
+  newparam(:name, :namevar => true) do
+    desc "The rhsm channel to subscribe to."
   end
 
 end


### PR DESCRIPTION
This is to pull in the beginning of RHSM Pool Support from the belminf fork of jlaska/puppet-subscription_manager.