### PR TITLE
Fixed bug with strings with numbers in them

### DIFF
--- a/lib/puppet/provider/rhsm_config/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_config/subscription_manager.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:rhsm_config).provide(:subscription_manager) do
           case raw_value
           when /\[\]/
             value = nil
-          when /\[(\d+)\]/, /(\d+)/
+          when /\[(\d+)\]/, /\s(\d+)\s/
             digit = $1
             if Puppet::Type.type(:rhsm_config).binary_options.has_key? "#{section}_#{title}".to_sym
               value = (digit == '1') ? true : false


### PR DESCRIPTION
When parsing a non-default string from 'subscription-manager config --list', and string with numbers in it would match the pattern (\d+) and discard all of the string except for the number.  Changed the regex to require whitespace on either side of the number to be considered a number.

for example:  hostname = anumberedserver01.domain.com would be return as '1', since the (\d+) matches just the 01, and then the digit.to_i converts '01' to just 1