### PR TITLE
ensure that Rhsm_register requires Rhsm_config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,7 +16,7 @@ class subscription_manager::config {
     'ensure'          => 'present',
   }
   $_reg_params = { "${::subscription_manager::server_hostname}" => $_settings, }
-  create_resources('rhsm_register', $_reg_params)
+  create_resources('rhsm_register', $_reg_params, {'require' => Rhsm_config['/etc/rhsm/rhsm.conf']})
 
   $_conf_params = { '/etc/rhsm/rhsm.conf' =>
     $::subscription_manager::config_hash, }

--- a/spec/classes/subscription_manager_spec.rb
+++ b/spec/classes/subscription_manager_spec.rb
@@ -19,7 +19,7 @@ describe 'subscription_manager' do
         it { is_expected.to compile.with_all_deps }
         it_behaves_like 'a supported operating system'
         it { is_expected.to contain_package('katello-ca-consumer-subscription.rhn.redhat.com') }
-        it { is_expected.to contain_rhsm_register('subscription.rhn.redhat.com') }
+        it { is_expected.to contain_rhsm_register('subscription.rhn.redhat.com').that_requires('Rhsm_config[/etc/rhsm/rhsm.conf]') }
         it { is_expected.to contain_rhsm_config('/etc/rhsm/rhsm.conf') }
       end
       describe "subscription_manager class with an activation key and server name on #{osfamily}" do
@@ -28,7 +28,7 @@ describe 'subscription_manager' do
         it { is_expected.to compile.with_all_deps }
         it_behaves_like 'a supported operating system'
         it { is_expected.to contain_package('katello-ca-consumer-foo') }
-        it { is_expected.to contain_rhsm_register('foo') }
+        it { is_expected.to contain_rhsm_register('foo').that_requires('Rhsm_config[/etc/rhsm/rhsm.conf]') }
         it { is_expected.to contain_rhsm_config('/etc/rhsm/rhsm.conf') }
       end
 


### PR DESCRIPTION
Hello,

thanks for the great module. I added a require for `Rhsm_config` to `Rhsm_register`. This fixes a problem you may run into if you unregister the machine and reset the `rhsm.conf` file while leaving the `katello-ca` rpm installed.