### PR TITLE
Added rhsm_only option

### DIFF
--- a/README
+++ b/README
@@ -123,6 +123,7 @@ to register.  Both cannot be provided and will cause an error.
 - **autosubscribe**: Enable automatic subscription to repositories based on default Pool settings. Must be false when using an activation key unless specifiying a service leve.
 - **servicelevel**: provide automatic attachement to a service level in Satellite. Not applicable to katello installations.
 - **force**: Should the registration be forced. Use this option with caution, setting it true will cause the system to be unregistered before running 'subscription-manager register'. Default value `false`.
+- **rhsm_only**: Should any repos not explicitly mentioned be removed?  When `true` this option will delete repo files not explicitly managed. Default value `false`.
 
 ### rhsm_register Examples
 

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -40,6 +40,9 @@ class subscription_manager::defaults {
       $force = false
       $org = 'Default_Organization'
       $repo = undef
+      $rhsm_only = false
+      $repodir = '/etc/yum.repos.d'
+      $rhsm_repofile = 'redhat.repo'
     }
     default: {
       fail("${::operatingsystem} not supported")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,9 @@ class subscription_manager (
   $org             = $::subscription_manager::defaults::org,
   $repo            = $::subscription_manager::defaults::repo,
   $config_hash     = $::subscription_manager::defaults::config_hash,
+  $rhsm_only       = $::subscription_manager::defaults::rhsm_only,
+  $repodir         = $::subscription_manager::defaults::repodir,
+  $rhsm_repofile   = $::subscription_manager::defaults::rhsm_repofile,
 ) inherits ::subscription_manager::defaults {
 
   # TODO: validate parameters here

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,22 @@
 #
 class subscription_manager::install {
 
+  if $::subscription_manager::rhsm_only {
+    # If we want rhsm repos only,
+    #   remove any repo file not explicitly managed within puppet
+    #   this doesn't stop you from telling puppet another repo matters too
+    file {${::subscription_manager::repodir}:
+      ensure  => directory,
+      recurse => true,
+      purge   => true,
+      require => File["${::subscription_manager::repodir}/${::subscription_manager::rhsm_repofile}"],
+    }
+    file {"${::subscription_manager::repodir}/${::subscription_manager::rhsm_repofile}":
+      ensure => present,
+      before => Package[$::subscription_manager::package_names],
+    }
+  }
+
   # any generic passed into the model
   package { $::subscription_manager::package_names:
     ensure => present,


### PR DESCRIPTION
This feature addition is not as well tested as I'd like, but it does make it easy to force only katello provided repos....