### PR TITLE
If we are going to manage goferd, we should install katello-agent

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -9,6 +9,7 @@ class subscription_manager::defaults {
     'RedHat', 'CentOS', 'Scientific', 'Fedora': {
       $server_hostname = 'subscription.rhn.redhat.com'
       $package_names = ['subscription-manager']
+      $service_packages = ['katello-agent']
       $service_name = 'goferd'
       $service_status = 'running'
       $config_hash = {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,7 @@
 #
 class subscription_manager (
   $package_names   = $::subscription_manager::defaults::package_names,
+  $service_packages= $::subscription_manager::defaults::service_packages,
   $service_name    = $::subscription_manager::defaults::service_name,
   $service_status  = $::subscription_manager::defaults::service_status,
   $server_hostname = $::subscription_manager::defaults::server_hostname,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,15 @@ class subscription_manager::install {
     ensure => present,
   }
 
+  if ($::subscription_manager::service_status in ['running', 'true']) {
+    # 'true' is another value for running per
+    #   https://docs.puppetlabs.com/puppet/latest/reference/type.html#service-attribute-ensure
+    package { $::subscription_manager::service_packages:
+      ensure  => present,
+      require => Package[ $::subscription_manager::package_names ]
+    }
+  }
+
   # support a custom repository if procided
   if $::subscription_manager::repo != '' and
     $::subscription_manager::repo != undef {


### PR DESCRIPTION
I've added another option so that katello-agent gets installed before attempting to start goferd.  While this could be done by editing the $package_names, it seemed to make more sense to me to optionally install katello-agent if we actually asked to start the daemon.