### PR TITLE
This is working on my lab with Puppet Entreprise 2016.1

### DIFF
--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -69,7 +69,7 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
   # trigger actions related to reistration on update of the properties
   def flush
     if exists?
-      if self.identity.nil?
+      if self.identity == :absent #self.identity.nil?
       # no valid registration
         register
         subscription_attach


### PR DESCRIPTION
Remove the nil? not working on my lab environment and changing to equal to == :absent.

Maybe a or should be used to be compatible with previous version. With 

`if self.identity == :absent || self.identity.nil?`

it also working on 2016.1