### PR TITLE
Avoid 'requiring' type modules which currently are not guaranteed to …

### DIFF
--- a/lib/puppet/provider/rhsm_config/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_config/subscription_manager.rb
@@ -8,7 +8,6 @@
 #   See LICENSE for licensing.
 #
 require 'puppet'
-require 'puppet/type/rhsm_config'
 
 Puppet::Type.type(:rhsm_config).provide(:subscription_manager) do
   @doc = <<-EOS

--- a/lib/puppet/provider/rhsm_override/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_override/subscription_manager.rb
@@ -8,7 +8,6 @@
 #   See LICENSE for licensing.
 #
 require 'puppet'
-require 'puppet/type/rhsm_override'
 require 'json'
 
 Puppet::Type.type(:rhsm_override).provide(:subscription_manager) do

--- a/lib/puppet/provider/rhsm_pool/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_pool/subscription_manager.rb
@@ -8,7 +8,6 @@
 #   See LICENSE for licensing.
 #
 require 'puppet'
-require 'puppet/type/rhsm_pool'
 require 'date'
 
 Puppet::Type.type(:rhsm_pool).provide(:subscription_manager) do

--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -9,7 +9,6 @@
 #
 require 'puppet'
 require 'facter'
-require 'puppet/type/rhsm_register'
 
 
 Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do

--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -8,7 +8,6 @@
 #   See LICENSE for licensing.
 #
 require 'puppet'
-require 'puppet/type/rhsm_repo'
 
 Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
   @doc = <<-EOS


### PR DESCRIPTION
…be in

the puppetserver's ruby interpreter load path.  Anyway, all that's needed is
puppet's type provider registration interface, not a particular type's definition.

see also issue #30