### PR TITLE
Resolution to module not getting parameters from Hiera in PE 2016.2.

### DIFF
--- a/README
+++ b/README
@@ -184,7 +184,7 @@ register.  Both cannot be provided and will cause an error.
 ##### Optional
 
 - **pool**: A specific license pool to attach the system to. Can include a default view using the formant pool-name/view-name.
-- **environment**: which environment to join at registration time
+- **smenvironment**: which environment to join at registration time
 - **autosubscribe**: Enable automatic subscription to repositories based on default Pool settings. Must be false when using an activation key unless specifying a service level.
 - **servicelevel**: provide automatic attachment to a service level in Satellite. Not applicable to katello installations.
 - **force**: Should the registration be forced. Use this option with caution, setting it true will cause the system to be unregistered before running 'subscription-manager register'. Default value `false`.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ register.  Both cannot be provided and will cause an error.
 ##### Optional
 
 - **pool**: A specific license pool to attach the system to. Can include a default view using the formant pool-name/view-name.
-- **environment**: which environment to join at registration time
+- **smenvironment**: which environment to join at registration time
 - **autosubscribe**: Enable automatic subscription to repositories based on default Pool settings. Must be false when using an activation key unless specifying a service level.
 - **servicelevel**: provide automatic attachment to a service level in Satellite. Not applicable to katello installations.
 - **force**: Should the registration be forced. Use this option with caution, setting it true will cause the system to be unregistered before running 'subscription-manager register'. Default value `false`.

--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -188,9 +188,9 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
       params << "--activationkey" <<  key
       # no autosubscribe with keys, see attach step instead
     end
-    if ((!@resource[:environment].nil? and !@resource[:environment] == :absent) and
+    if ((!@resource[:smenvironment].nil? and !@resource[:smenvironment] == :absent) and
       (@resource[:activationkey].nil? or @resource[:activationkey] == :absent))
-     params << "--environment" << @resource[:environment]
+     params << "--environment" << @resource[:smenvironment]
     end
     params << "--org" << @resource[:org]
     return params

--- a/lib/puppet/type/rhsm_register.rb
+++ b/lib/puppet/type/rhsm_register.rb
@@ -78,7 +78,7 @@ EOD
     desc "The license pool to attach to after registering the system"
   end
 
-  newparam(:environment) do
+  newparam(:smenvironment) do
     desc "The environment to subscribe to in the case of using katello."
   end
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@ class subscription_manager::config {
     'username'        => $::subscription_manager::username,
     'password'        => $::subscription_manager::password,
     'pool'            => $::subscription_manager::pool,
-    'environment'     => $::subscription_manager::environment,
+    'smenvironment'   => $::subscription_manager::smenvironment,
     'autosubscribe'   => $::subscription_manager::autosubscribe,
     'force'           => $::subscription_manager::force,
     'org'             => $::subscription_manager::org,

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -33,7 +33,7 @@ class subscription_manager::defaults {
     $activationkey = undef
     $pool = undef
     $servicelevel = undef
-    $environment = undef # cannot use with an activation key!
+    $smenvironment = undef # cannot use with an activation key!
     $autosubscribe = false
     $force = false
     $org = 'Default_Organization'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@
 #    * password
 #    * activationkeys
 #    * pool
-#    * environment
+#    * smenvironment
 #    * autosubscribe
 #    * servicelevel
 #    * force
@@ -76,7 +76,7 @@ class subscription_manager (
   $password        = $::subscription_manager::defaults::password,
   $activationkey   = $::subscription_manager::defaults::activationkey,
   $pool            = $::subscription_manager::defaults::pool,
-  $environment     = $::subscription_manager::defaults::environment,
+  $smenvironment     = $::subscription_manager::defaults::smenvironment,
   $autosubscribe   = $::subscription_manager::defaults::autosubscribe,
   $servicelevel    = $::subscription_manager::defaults::servicelevel,
   $force           = $::subscription_manager::defaults::force,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,7 +38,7 @@ class subscription_manager::install {
     ensure   => 'latest',
     provider => 'rpm',
     source   =>
-  "http://${::subscription_manager::server_hostname}/pub/${::ca_package_prefix}latest.noarch.rpm",
+  "http://${::subscription_manager::server_hostname}/pub/${::subscription_manager::ca_package_prefix}latest.noarch.rpm",
   }
 
   # II. registered to correct server

--- a/spec/unit/provider/rhsm_register/subscription_manager_spec.rb
+++ b/spec/unit/provider/rhsm_register/subscription_manager_spec.rb
@@ -24,7 +24,7 @@ describe  provider_class, 'rhsm_register provider' do
     :username      => 'registered_user',
     :password      => 'password123',
     :activationkey => '1-my-activation-key',
-    :environment   => 'lab',
+    :smenvironment => 'lab',
     :autosubscribe => true,
     :force         => true,
     :org           => 'the cool organization',
@@ -168,7 +168,7 @@ describe  provider_class, 'rhsm_register provider' do
         :ensure => :present,
         :activationkey => fake_key,
         :org => 'foo',
-        :environment => 'pants',
+        :smenvironment => 'pants',
         :servicelevel => 'STANDARD',
         :autosubscribe => true,
         :provider => :subscription_manager,)

--- a/spec/unit/type/rhsm_register_spec.rb
+++ b/spec/unit/type/rhsm_register_spec.rb
@@ -27,7 +27,7 @@ describe described_class, 'type' do
     expect(described_class.attrtype(:ensure)).to eq(:property)
   end
 
-  [ :username, :password, :org, :activationkey, :environment,
+  [ :username, :password, :org, :activationkey, :smenvironment,
     :pool, :servicelevel ].each { |params|
       context "for #{params}" do
         it "should be of type paramter" do


### PR DESCRIPTION
After some tests I got the problem to a specific variable named $environment.
Changing the variable name to something else let the module work with PE 2016.2.
I've changed the variable name from $environment to $smenvironment on every file.
There's also a fix for the ${::ca_package_prefix} variable that should be ${::subscription_manager::ca_package_prefix}
Tested with PE2016.2 - RHEL7 - RedHat SAM1.4

Related to Issue #32 and #33 
