### PR TITLE
Exclude additional keys

### DIFF
--- a/lib/puppet/provider/rhsm_config/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_config/subscription_manager.rb
@@ -172,7 +172,7 @@ Puppet::Type.type(:rhsm_config).provide(:subscription_manager) do
       params << "config"
       # only set non-empty non-equal values
       @property_hash.keys.each { |key|
-        unless key == :ensure or key == :title or key == :tags
+        unless key == :ensure or key == :title or key == :tags or key == :name or key == :provider
           section = key.to_s.sub('_','.')
           if config == :remove or (@property_hash[key] == '' and @property_hash[key] != @resource[key])
             params << "--remove=#{section}" unless key == :name


### PR DESCRIPTION
Exclude additional keys. Otherwise subscription will fail:

Error: /Stage[main]/Subscription_manager::Config/Rhsm_config[/etc/rhsm/rhsm.conf]: Could not evaluate: Execution of '/sbin/subscription-manager config --server.hostname […] --logging.default_log_level INFO --name /etc/rhsm/rhsm.conf --provider subscription_manager' returned 2: Usage: subscription-manager config [OPTIONS]
 
subscription-manager: error: no such option: --name