### PR TITLE
Add katello-default-ca.pem to the list of certs

### DIFF
--- a/lib/facter/rhsm_ca_name.rb
+++ b/lib/facter/rhsm_ca_name.rb
@@ -31,14 +31,15 @@ EOF
 end
 
 cafile = nil
-if File.exists?('/etc/rhsm/ca/katello-server-ca.pem')
+if File.exists?('/etc/rhsm/ca/katello-default-ca.pem')
+  # Katello or Satellite with custom CA cert
+  cafile = '/etc/rhsm/ca/katello-default-ca.pem'
+elsif File.exists?('/etc/rhsm/ca/katello-server-ca.pem')
   # Katello or Satellite
   cafile = '/etc/rhsm/ca/katello-server-ca.pem'
-else
-  if File.exists?('/etc/rhsm/ca/candlepin-local.pem')
-    # RedHat SAM
-    cafile = '/etc/rhsm/ca/candlepin-local.pem'
-  end
+elsif File.exists?('/etc/rhsm/ca/candlepin-local.pem')
+  # RedHat SAM
+  cafile = '/etc/rhsm/ca/candlepin-local.pem'
 end
 if !(cafile.nil?)
     Facter.add(:rhsm_ca_name) do

--- a/spec/functions/rhsm_ca_name_spec.rb
+++ b/spec/functions/rhsm_ca_name_spec.rb
@@ -11,6 +11,7 @@ require 'spec_helper'
 require 'facter/rhsm_ca_name'
 
 cafiles = {
+  'katellodefault' => '/etc/rhsm/ca/katello-default-ca.pem',
   'katello' => '/etc/rhsm/ca/katello-server-ca.pem',
   'sam' => '/etc/rhsm/ca/candlepin-local.pem',
 }


### PR DESCRIPTION
When a custom CA is used with katello, the default CA certificate is created as katello-default-ca.pem and the custom CA's certificate is placed in katello-server-ca.pem.

If katello-default-ca.pem exists, we use that instead of katello-server-ca.pem. 

This ensures the fact contains the katello/satellite hostname as before.