### PR TITLE
Allow the ca package to be excluded to support registering with RedHat

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -4,6 +4,7 @@ subscription_manager::package_names:
   - 'subscription-manager'
 subscription_manager::service_name: 'goferd'
 subscription_manager::service_status: 'running'
+subscription_manager::ca_package: true
 subscription_manager::ca_package_prefix: 'katello-ca-consumer-'
 subscription_manager::autosubscribe: false
 subscription_manager::force: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,7 @@
 #
 class subscription_manager (
   Array[String] $package_names = ['subscription-manager'],
+  Boolean $ca_package = true,
   String $ca_package_prefix = 'katello-ca-consumer-',
   String $service_name = 'goferd',
   Enum['running','stopped', 'disabled', 'enabled'] $service_status = 'running',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,62 +45,63 @@ class subscription_manager::install {
       -> Package[ $::subscription_manager::package_names ]
   }
 
-  # shorten several really long names
-  $_ca       = $::facts['rhsm_ca_name']
-  $_id       = $::facts['rhsm_identity']
-  $_prefix   = $::subscription_manager::ca_package_prefix
-  $_hostname = $::subscription_manager::server_hostname
-  $_pkg      = "${_prefix}${_hostname}" # 80-column puppet-lint limit workaround
+  if $::subscription_manager::ca_package {
+    # shorten several really long names
+    $_ca       = $::facts['rhsm_ca_name']
+    $_id       = $::facts['rhsm_identity']
+    $_prefix   = $::subscription_manager::ca_package_prefix
+    $_hostname = $::subscription_manager::server_hostname
+    $_pkg      = "${_prefix}${_hostname}" # 80-column puppet-lint limit workaround
 
-  # four scenarios
-  # I.  never registered
-  #  - no ca_name
-  #  - no identity
-  #  - just install normally
-  package { $_pkg:
-    ensure   => 'present',
-    provider => 'rpm',
-    source   =>
-  "http://${_hostname}/pub/${_prefix}latest.noarch.rpm",
-  }
+    # four scenarios
+    # I.  never registered
+    #  - no ca_name
+    #  - no identity
+    #  - just install normally
+    package { $_pkg:
+      ensure   => 'present',
+      provider => 'rpm',
+      source   =>
+    "http://${_hostname}/pub/${_prefix}latest.noarch.rpm",
+    }
 
-  # II. registered to correct server
-  #  - ca_name == server_hostname
-  #  - identity is set
-  #  - do nothing new, let puppet idempotency handle it
+    # II. registered to correct server
+    #  - ca_name == server_hostname
+    #  - identity is set
+    #  - do nothing new, let puppet idempotency handle it
 
-  # III. registered to different server
-  #  - ca_name != server_hostname
-  #  - identity may or may not be set
-  #  - remove old, install new
-  if $_ca != '' and $_ca != undef {
-    # an SSL Certificate Authority is detected
-    # does it match server_hostname (aka _suffix for the package)
-    if $_ca != $_hostname {
-      # but CA is changing
-      # remove the old package
-      package { "${_prefix}${_ca}": ensure => 'absent', }
-      Package["${_prefix}${_ca}"] -> Package[$_pkg]
+    # III. registered to different server
+    #  - ca_name != server_hostname
+    #  - identity may or may not be set
+    #  - remove old, install new
+    if $_ca != '' and $_ca != undef {
+      # an SSL Certificate Authority is detected
+      # does it match server_hostname (aka _suffix for the package)
+      if $_ca != $_hostname {
+        # but CA is changing
+        # remove the old package
+        package { "${_prefix}${_ca}": ensure => 'absent', }
+        Package["${_prefix}${_ca}"] -> Package[$_pkg]
+      }
+    }
+
+    # IV. registered to same server but CA is bad
+    #  - ca_name == server_hostname
+    #  - identity is not set
+    #  - reinstall (this requires a pupetlabs-transition)
+    # This case is meant to prevent extra regitrations on pre-6.2 Satellite
+    if ((($_id == '' or $_id == undef) and $_ca == $_hostname) or
+      ($_ca == $_hostname and $::subscription_manager::force == true )) {
+      $_attributes = {
+        'ensure'          => 'absent',
+        'provider'        => 'rpm',
+        'install_options' => [ '--force', '--nodeps' ],
+      }
+      transition {'purge-bad-rhsm_ca-package':
+        resource   => Package[$_pkg],
+        attributes => $_attributes,
+        prior_to   => Package[$_pkg],
+      }
     }
   }
-
-  # IV. registered to same server but CA is bad
-  #  - ca_name == server_hostname
-  #  - identity is not set
-  #  - reinstall (this requires a pupetlabs-transition)
-  # This case is meant to prevent extra regitrations on pre-6.2 Satellite
-  if ((($_id == '' or $_id == undef) and $_ca == $_hostname) or
-    ($_ca == $_hostname and $::subscription_manager::force == true )) {
-    $_attributes = {
-      'ensure'          => 'absent',
-      'provider'        => 'rpm',
-      'install_options' => [ '--force', '--nodeps' ],
-    }
-    transition {'purge-bad-rhsm_ca-package':
-      resource   => Package[$_pkg],
-      attributes => $_attributes,
-      prior_to   => Package[$_pkg],
-    }
-  }
-
 }

--- a/spec/classes/subscription_manager_spec.rb
+++ b/spec/classes/subscription_manager_spec.rb
@@ -114,6 +114,23 @@ describe 'subscription_manager' do
         it { is_expected.to contain_rhsm_config('/etc/rhsm/rhsm.conf') }
         it { is_expected.to contain_transition('purge-bad-rhsm_ca-package') }
       end
+      describe "subscription_manager class without ca_package on #{os}" do
+        let(:facts) do
+          facts.merge({
+            :rhsm_ca_name => 'foo',
+            :rhsm_identity => ''# no rhsm_register without force if identity is valid
+          })
+        end
+        let(:params) {{
+          :activationkey => 'foo-bar',
+          :server_hostname => 'foo',
+          :ca_package => false,
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it_behaves_like 'a supported operating system'
+        it { is_expected.to_not contain_package('katello-ca-consumer-foo') }
+        it { is_expected.to_not contain_transition('purge-bad-rhsm_ca-package') }
+      end
       describe "subscription_manager class with an identity on #{os}" do
         let(:facts) do
           facts.merge({


### PR DESCRIPTION
My systems don't (yet) use Satellite or Katello but instead register directly with RedHat.  This change is one of possibly many to allow the `subscription_manager` class to be used for registration directly with RedHat.