### PR TITLE
Added support for repomd_gpg_url config parmeter

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -22,6 +22,7 @@ subscription_manager::config_hash:
     rhsm_manage_repos: true
     rhsmcertd_certcheckinterval: 240
     rhsmcertd_autoattachinterval: 1440
+    rhsm_repomd_gpg_url: ''
 # also, proxy settings
 #    server_proxy_hostname: ''
 #    server_proxy_port: ''

--- a/lib/puppet/type/rhsm_config.rb
+++ b/lib/puppet/type/rhsm_config.rb
@@ -66,6 +66,7 @@ def self.text_options
   :rhsm_consumercertdir => 'rhsm.consumercertdir',
   :rhsm_pluginconfdir => 'rhsm.pluginconfdir',
   :rhsm_plugindir => 'rhsm.plugindir',
+  :rhsm_repomd_gpg_url => 'rhsm.repomd_gpg_url',
   :rhsmcertd_certcheckinterval => 'rhsmcertd.certcheckinterval',
   :rhsmcertd_autoattachinterval => 'rhsmcertd.autoattachinterval',
   :logging_default_log_level => 'logging.default_log_level',
@@ -324,6 +325,10 @@ end
     validate do |value|
       fail("Require a small positive number. Was given #{value}.") unless value.to_i and (value.to_i >= 0)
     end
+  end
+
+  newproperty(:rhsm_repomd_gpg_url) do
+    desc "Repo gpg"
   end
 
 end


### PR DESCRIPTION
Added feature for repomd_gpg_url (required for subscription-manager versions >= 1.21.10-2)
With the latest release of RHEL 7.6, subscription manager got updated and the module doesn't support the new feature (it fails at puppet run).

I appreciate if you merge the pull request as soon as possible. Please let me know if there is anything else I could do.

Thanks!