### PR TITLE
self.repo_cert is broken

### DIFF
--- a/lib/puppet/provider/rhsm_config/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_config/subscription_manager.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:rhsm_config).provide(:subscription_manager) do
     value = nil
     begin
       on_disk = File.open(configname)
-      on_disk.split("\n").each do |line|
+      on_disk.readlines.each do |line|
         m = line.match(%r{[^#]*repo_ca_cert = (.+)})
         unless m.nil?
           value = m[1].strip


### PR DESCRIPTION
File.split(value) does not split the file content in to an array based on the provided value. It splits the provided value in to a two-element array.

The correct function is File.readlines.