### PR TITLE
Fix provider prefetching to handle resources not being present

### DIFF
--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -116,7 +116,9 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
 
   def self.prefetch(resources)
     resources.keys.each do |name|
-      resources[name].provider = instances.find { |instance| instance.name == name }
+      if provider = instances.find { |instance| instance.name == name }
+        resources[name].provider = provider
+      end
     end
   end
 

--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -45,7 +45,9 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
   def self.prefetch(resources)
     repos = instances
     resources.keys.each do |name|
-      resources[name].provider = repos.find { |repo| repo.name == name }
+      if provider = repos.find { |repo| repo.name == name }
+        resources[name].provider = provider
+      end
     end
   end
 


### PR DESCRIPTION
I defined `rhel-7-server-eus-rpms` as `absent` and it's not a repo available to my satellite content view so ended up having no provider during prefetch so without this change the provider was getting set to nil.  The line numbers won't match up in backtrace because I added lots of debug printing but errors are gone with this fix.

```
Error: Failed to apply catalog: undefined method `intern' for nil:NilClass
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1798:in `provider'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:2011:in `provider='
/opt/puppetlabs/puppet/cache/lib/puppet/provider/rhsm_repo/subscription_manager.rb:50:in `block in prefetch'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/rhsm_repo/subscription_manager.rb:48:in `each'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/rhsm_repo/subscription_manager.rb:48:in `prefetch'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:360:in `prefetch'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:252:in `prefetch_if_necessary'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:111:in `block in evaluate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/graph/relationship_graph.rb:119:in `traverse'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:173:in `evaluate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:239:in `block (2 levels) in apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:519:in `block in thinmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:518:in `thinmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:238:in `block in apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:156:in `with_destination'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction/report.rb:146:in `as_logging_destination'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:237:in `apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:186:in `block (2 levels) in apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:519:in `block in thinmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:518:in `thinmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:185:in `block in apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:232:in `block in benchmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:231:in `benchmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:184:in `apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:369:in `run_internal'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:237:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:65:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:260:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:211:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:59:in `block (5 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/timeout.rb:76:in `timeout'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:58:in `block (4 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent/locker.rb:21:in `lock'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:52:in `block (3 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:130:in `with_client'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:49:in `block (2 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:87:in `run_in_fork'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:48:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:179:in `controlled_run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:46:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/agent.rb:372:in `onetime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/agent.rb:350:in `run_command'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:375:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:667:in `exit_on_fail'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:375:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:135:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:73:in `execute'
/opt/puppetlabs/puppet/bin/puppet:5:in `<main>'

```