### PR TITLE
Fix rhsm_repo to not raise exception when not registered

### DIFF
--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
 
   def self.instances
     repos = read_repos
-    if repos.nil? || repos == []
+    if repos.nil? || repos == [] || repos == [{}]
       []
     else
       repos.map do |repo|

--- a/spec/unit/provider/rhsm_repo/subscription_manager_spec.rb
+++ b/spec/unit/provider/rhsm_repo/subscription_manager_spec.rb
@@ -109,6 +109,12 @@ EOT
       repos = provider.class.instances
       expect(repos.size).to eq(0)
     end
+    it 'returns nothing for not subscribed' do
+      data = 'This system has no repositories available through subscriptions.'
+      expect(provider.class).to receive(:subscription_manager).with('repos').and_return(data)
+      repos = provider.class.instances
+      expect(repos.size).to eq(0)
+    end
   end
 
   describe 'self.prefetch' do


### PR DESCRIPTION
Ran into this with unregistered system and using `resources { 'rhsm_repo': purge => true }`.