### PR TITLE
Fix provider prefetching to handle resources not being present

### DIFF
--- a/lib/puppet/provider/rhsm_register/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_register/subscription_manager.rb
@@ -116,7 +116,10 @@ Puppet::Type.type(:rhsm_register).provide(:subscription_manager) do
 
   def self.prefetch(resources)
     resources.keys.each do |name|
-      resources[name].provider = instances.find { |instance| instance.name == name }
+      provider = instances.find { |instance| instance.name == name }
+      if provider
+        resources[name].provider = provider
+      end
     end
   end
 

--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -45,7 +45,10 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
   def self.prefetch(resources)
     repos = instances
     resources.keys.each do |name|
-      resources[name].provider = repos.find { |repo| repo.name == name }
+      provider = repos.find { |repo| repo.name == name }
+      if provider
+        resources[name].provider = provider
+      end
     end
   end
 


### PR DESCRIPTION
Fixed rubocop failures present in #79.  Running rubocop locally shows a lot of failures unrelated to this change.