### PR TITLE
Do not create rhsm_repo instances for invalid repos

### DIFF
--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -37,8 +37,6 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
       []
     else
       repos.map do |repo|
-        next if repo.empty?
-        next unless repo[:name]
         new(repo)
       end
     end
@@ -108,7 +106,10 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
     end
     unless repos.nil? || repos == "\n\n" || repos == ''
       repos.split("\n\n").each do |repo|
-        repo_instances.push(parse_repos(repo))
+        parsed_repo = parse_repos(repo)
+        next if parsed_repo.empty?
+        next unless parsed_repo[:name]
+        repo_instances.push(parsed_repo)
       end
     end
     repo_instances

--- a/lib/puppet/provider/rhsm_repo/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_repo/subscription_manager.rb
@@ -37,6 +37,8 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
       []
     else
       repos.map do |repo|
+        next if repo.empty?
+        next unless repo[:name]
         new(repo)
       end
     end
@@ -88,6 +90,7 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
         new_repo[:ensure] = (value == 1) ? :present : :absent
       end
     end
+    Puppet.debug("PARSED REPO: #{new_repo}")
     new_repo
   end
 
@@ -98,6 +101,7 @@ Puppet::Type.type(:rhsm_repo).provide(:subscription_manager) do
     repo_instances = []
     begin
       repos = subscription_manager('repos')
+      Puppet.debug("REPOS: #{repos}")
     rescue StandardError => e
       Puppet.debug("No repositories found (#{e}).")
       repos = ''


### PR DESCRIPTION
I ran into issues where locks in Satellite would produce errors in subscription-manager and the parsed repo was empty Hash and breaking Puppet.

I use this:
```puppet
resources { 'rhsm_repo': purge => true }
```

And got this:

```
2019-09-17 10:55:05 -0400 /Stage[main]/Satellite::Yumrepos::Redhat/Resources[rhsm_repo] (err): Failed to generate additional resources using 'generate': No resource and no name in property hash in subscription_manager instance
```

Debug output that shows the issue:
```
2019-09-17 10:54:58 -0400 Puppet (debug): Executing: '/sbin/subscription-manager repos'
2019-09-17 10:55:05 -0400 Puppet (debug): REPOS: Internal Server Error): Required lock is already taken by other running tasks.
Please inspect their state, fix their errors and resume them.

Required lock: update
Conflicts with tasks:
  https://satellite<OMIT>/foreman_tasks/tasks/37265fb0 7a8f 4b6d aa30 5e5facd82370

+----------------------------------------------------------+
    Available Repositories in /etc/yum.repos.d/redhat.repo
+----------------------------------------------------------+

<SNIP>

2019-09-17 10:55:05 -0400 Puppet (debug): PARSED REPO: {}
2019-09-17 10:55:05 -0400 Puppet (debug): PARSED REPO: {}

<SNIP>
```