### PR TITLE
add nil value handling in rhsm_ facts

### DIFF
--- a/lib/facter/rhsm_available_pools.rb
+++ b/lib/facter/rhsm_available_pools.rb
@@ -39,7 +39,7 @@ EOF
   end
 
   def rhsm_available_pools
-    value = []
+    value = nil
     begin
       available = Facter::Core::Execution.execute(
         '/usr/sbin/subscription-manager list --available',
@@ -73,7 +73,7 @@ if File.exist? '/usr/sbin/subscription-manager'
             :rhsm_available_pools,
             pool,
             pools::CACHE_FILE,
-          )
+          ) unless pool.nil?
           pool
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_available_repos.rb
+++ b/lib/facter/rhsm_available_repos.rb
@@ -28,7 +28,7 @@ EOF
   module_function
 
   def rhsm_available_repos
-    value = []
+    value = nil
     begin
       output = Facter::Core::Execution.execute(
         '/usr/sbin/subscription-manager repos',
@@ -65,7 +65,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           repo = repos.rhsm_available_repos
           Facter::Util::FacterCacheable.cache(
             :rhsm_available_repos, repo, repos::CACHE_FILE
-          )
+          ) unless repo.nil?
           repo
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_disabled_pools.rb
+++ b/lib/facter/rhsm_disabled_pools.rb
@@ -48,7 +48,7 @@ EOF
   end
 
   def rhsm_disabled_pools
-    value = []
+    value = nil
     begin
       consumed = Facter::Core::Execution.execute(
         '/usr/sbin/subscription-manager list --consumed',
@@ -79,7 +79,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           pool = pools.rhsm_disabled_pools
           Facter::Util::FacterCacheable.cache(
             :rhsm_disabled_pools, pool, pools::CACHE_FILE
-          )
+          ) unless pool.nil?
           pool
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_disabled_repos.rb
+++ b/lib/facter/rhsm_disabled_repos.rb
@@ -28,7 +28,7 @@ EOF
   module_function
 
   def rhsm_disabled_repos
-    value = []
+    value = nil
     begin
       reponame = ''
       output = Facter::Core::Execution.execute(
@@ -61,8 +61,6 @@ if File.exist? '/usr/sbin/subscription-manager'
   repos = Facter::Util::RhsmDisabledRepos
   if Puppet.features.facter_cacheable?
     Facter.add(:rhsm_disabled_repos) do
-      confine { File.exist? '/usr/sbin/subscription-manager' }
-      confine { Puppet.features.facter_cacheable? }
       setcode do
         # TODO: use another fact to set the TTL in userspace
         # right now this can be done by removing the cache files
@@ -73,7 +71,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           repo = repos.rhsm_disabled_repos
           Facter::Util::FacterCacheable.cache(
             :rhsm_disabled_repos, repo, repos::CACHE_FILE
-          )
+          ) unless repo.nil?
           repo
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_enabled_pools.rb
+++ b/lib/facter/rhsm_enabled_pools.rb
@@ -48,7 +48,7 @@ EOF
   end
 
   def rhsm_enabled_pools
-    value = []
+    value = nil
     begin
       consumed = Facter::Core::Execution.execute(
         '/usr/sbin/subscription-manager list --consumed',
@@ -79,7 +79,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           pool = pools.rhsm_enabled_pools
           Facter::Util::FacterCacheable.cache(
             :rhsm_enabled_pools, pool, pools::CACHE_FILE
-          )
+          ) unless pool.nil?
           pool
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_enabled_repos.rb
+++ b/lib/facter/rhsm_enabled_repos.rb
@@ -28,7 +28,7 @@ EOF
   module_function
 
   def rhsm_enabled_repos
-    value = []
+    value = nil
     begin
       reponame = ''
       output = Facter::Core::Execution.execute(
@@ -71,7 +71,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           repo = repos.rhsm_enabled_repos
           Facter::Util::FacterCacheable.cache(
             :rhsm_enabled_repos, repo, repos::CACHE_FILE
-          )
+          ) unless repo.nil?
           repo
         elsif cache.is_a? Array
           cache

--- a/lib/facter/rhsm_identity.rb
+++ b/lib/facter/rhsm_identity.rb
@@ -3,7 +3,7 @@
 
 #
 #  Report the name of the client ID.
-#  This will be null if the reigstration is bad.
+#  This will be null if the registration is bad.
 #
 #   Copyright 2014-2015 Gaël Chamoulaud, James Laska
 #
@@ -65,7 +65,7 @@ if File.exist? '/usr/sbin/subscription-manager'
           identity = identities.rhsm_identity
           Facter::Util::FacterCacheable.cache(
             :rhsm_identity, identity, identities::CACHE_FILE
-          )
+          ) unless identity.nil?
           identity
         elsif cache.is_a? Array
           cache


### PR DESCRIPTION
if subscription-manager hasn't failed, nil values would be passed for caching, causing errors in the puppet output

Also, make facter code more uniform
