### PR TITLE
Subscription manager on RHEL 7.8 now uses Entitlement Type for subscriptions

### DIFF
--- a/lib/puppet/provider/rhsm_pool/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_pool/subscription_manager.rb
@@ -90,9 +90,9 @@ Puppet::Type.type(:rhsm_pool).provide(:subscription_manager) do
         subscription.store(:active, value)
         next
       end
-      m = %r{^\s*System Type:\s*([^:]+)$}.match(line)
+      m = %r{^\s*(System|Entitlement) Type:\s*([^:]+)$}.match(line)
       unless m.nil?
-        value = m[1].strip.to_sym
+        value = m[2].strip.to_sym
         subscription.store(:system_type, value)
         # this is the last item output
         subscription.store(:provider, :subscription_manager)


### PR DESCRIPTION
This is what I have on RHEL 7.8 server:

```
[root@satellite-test ~]# subscription-manager list --consumed | tail -n 5
Subscription Type:   Standard
Starts:              07/02/2019
Ends:                07/01/2020
Entitlement Type:    Physical

```