### PR TITLE
adds name property to rhsm_pool and get serial from the instance property_hash

### DIFF
--- a/lib/puppet/provider/rhsm_pool/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_pool/subscription_manager.rb
@@ -82,6 +82,7 @@ Puppet::Type.type(:rhsm_pool).provide(:subscription_manager) do
         value = m[1].strip
         subscription[:id] = value
         # this creates a 'fake' name resource to deal with the missing name parameter
+        subscription[:name] = value
         next
       end
       m = %r{^\s*Active:\s*(.+)$}.match(line)

--- a/lib/puppet/provider/rhsm_pool/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_pool/subscription_manager.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:rhsm_pool).provide(:subscription_manager) do
   # Detach from a pool
   #  Given the serial number of our registration, remove the license
   def destroy
-    subscription_manager('remove', '--serial', @resource[:serial])
+    subscription_manager('remove', '--serial', @property_hash[:serial])
   end
 
   #  List the pools

--- a/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
+++ b/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
@@ -208,17 +208,17 @@ describe provider_class, '#rhsm_pool.provider' do
     end
     it "destroy should detach from a pool that shouldn't exist" do
       serial = '1234567890123456789'
-      expect(provider).to receive(:subscription_manager).with(
-        'remove', '--serial', serial
-      )
-      Puppet::Type.type(:rhsm_pool).new(
+      res = Puppet::Type.type(:rhsm_pool).new(
         name: title1,
-        ensure: :absent,
-        serial: serial,
         provider: provider,
       )
-      allow(provider).to receive(:exists?).and_return(false)
-      provider.destroy
+      res.provider.set(ensure: :absent)
+      res.provider.set(serial: serial)
+      allow(res.provider).to receive(:exists?).and_return(false)
+      expect(res.provider).to receive(:subscription_manager).with(
+        'remove', '--serial', serial
+      )
+      res.provider.destroy
     end
   end
 end

--- a/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
+++ b/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
@@ -201,7 +201,7 @@ describe provider_class, '#rhsm_pool.provider' do
       expect(provider).to receive(:subscription_manager).with(
         'attach', '--pool', title1
       )
-      Puppet::Type.type(:rhsm_pool).new(name: title1,
+      Puppet::Type.type(:rhsm_pool).new(id: title1,
                                         ensure: :present, provider: provider)
       allow(provider).to receive(:exists?).and_return(true)
       provider.create
@@ -209,7 +209,7 @@ describe provider_class, '#rhsm_pool.provider' do
     it "destroy should detach from a pool that shouldn't exist" do
       serial = '1234567890123456789'
       res = Puppet::Type.type(:rhsm_pool).new(
-        name: title1,
+        id: title1,
         provider: provider,
       )
       res.provider.set(ensure: :absent)


### PR DESCRIPTION
This pull-request silently re-adds the name property to work around a known puppet limitation.