### PR TITLE
fix rhsmd.processTimeout support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 2020-4-28 5.5.0
- - Support rhsm.processTimeout in #97
+ - Support rhsmd.processtimeout in #97
  - Include masking of Entitlement type per MR in #99
  
 2020-04-28 5.4.2

--- a/lib/facter/rhsm_identity.rb
+++ b/lib/facter/rhsm_identity.rb
@@ -10,8 +10,6 @@
 #   See LICENSE for licensing.
 #
 
-
-
 require 'English'
 
 begin

--- a/lib/puppet/type/rhsm_config.rb
+++ b/lib/puppet/type/rhsm_config.rb
@@ -72,6 +72,7 @@ EOD
       rhsm_plugindir: 'rhsm.plugindir',
       rhsmcertd_certcheckinterval: 'rhsmcertd.certcheckinterval',
       rhsmcertd_autoattachinterval: 'rhsmcertd.autoattachinterval',
+      rhsmd_processtimeout: 'rhsmd.processtimeout',
       logging_default_log_level: 'logging.default_log_level',
       logging_subscription_manager: 'logging.subscription_manager',
       logging_rhsm: 'logging.rhsm',
@@ -199,10 +200,10 @@ EOD
     end
   end
 
-  newproperty(:rhsmd_processTimeout) do
+  newproperty(:rhsmd_processtimeout) do
     desc 'Control how long to allow the rhsmd cron job to run'
     validate do |value|
-      raise("Require a number.  Was given #{value}.") unless value.to_i and value.to_i >= 0
+      raise("Require a number. Was given #{value}.") unless value.to_i && value.to_i >= 0
     end
   end
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -9,7 +9,6 @@ SimpleCov.start do
   add_filter '/.bundle/'
 end
 
-
 ARGV.clear
 
 require 'puppet'
@@ -21,7 +20,7 @@ require 'rspec/expectations'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
-  # FIXME REVISIT - We may want to delegate to Facter like we do in
+  # FIXME: We may want to delegate to Facter like we do in
   # Puppet::PuppetSpecInitializer.initialize_via_testhelper(config) because
   # this behavior is a duplication of the spec_helper in Facter.
   config.before :each do
@@ -31,7 +30,7 @@ RSpec.configure do |config|
     # Facter.collection.loader.load(:ipaddress)
     # Facter::Util::Loader.any_instance.stubs(:load_all) # removed in 3
     Facter.clear
-    #Facter.clear_messages # removed in facter 3
+    # Facter.clear_messages # removed in facter 3
   end
   # config.pattern += ',spec/facter/**/*_spec.rb'
   config.mock_with :rspec

--- a/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
+++ b/spec/unit/provider/rhsm_pool/subscription_manager_spec.rb
@@ -36,7 +36,7 @@ Ends:              05/24/38
 System Type:       Physical
 EOD
 
-entitlement_data = raw_data.sub('System Type','Entitlement Type')
+entitlement_data = raw_data.sub('System Type', 'Entitlement Type')
 
 title1 = '1a2b3c4d5e6f1234567890abcdef12345'
 title2 = '1234abc'
@@ -61,7 +61,6 @@ properties = {
   system_type: 'Physical',
   provider: :subscription_manager,
 }
-
 
 provider_class = Puppet::Type.type(:rhsm_pool).provider(:subscrption_manager)
 

--- a/spec/unit/type/rhsm_config_spec.rb
+++ b/spec/unit/type/rhsm_config_spec.rb
@@ -28,7 +28,7 @@ require 'spec_helper'
 #   rhsm_repo_ca_cert           => '/etc/rhsm/ca/',
 #   rhsm_report_package_profile => 1,
 #   rhsmcertd_autoattachinterval => 1440,
-#   rhsm_processTimeout => 3600,
+#   rhsmd_processtimeout => 3600,
 # }
 
 described_class = Puppet::Type.type(:rhsm_config)


### PR DESCRIPTION
It seems even though documentation shows camel case of the parameter it reports it in lowercase:

```
# subscription-manager config --list
[rhsmd]
   processtimeout = [300]
```

also seems puppet resources attributes can't be uppercase either