### PR TITLE
Fix puppet requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.12"
+      "version_requirement": ">= 5.0.0"
     }
   ],
   "description": "Register CentOS or RHEL to Katello or Satellite 6.",


### PR DESCRIPTION
Lost some time understanding why this module was not working for us on puppet 4 (yeah I know it's 2020)
Main reason is: "String does not have match? in ruby 2.1 which is coming with puppet 4"