### PR TITLE
Fix help parsing regex

### DIFF
--- a/lib/puppet/provider/rhsm_config/subscription_manager.rb
+++ b/lib/puppet/provider/rhsm_config/subscription_manager.rb
@@ -241,7 +241,7 @@ Puppet::Type.type(:rhsm_config).provide(:subscription_manager) do
     opts = []
     unless data.nil?
       data.split("\n").each do |line|
-        m = line.match(%r{^\s+--([a-z_0-9]+\.[a-z_0-9]+) [A-Z]+.*})
+        m = line.match(%r{^\s+--([a-z_0-9]+\.[a-z_0-9]+)[=\s][A-Z]+.*})
         unless m.nil?
           opts.push m[1]
         end


### PR DESCRIPTION
Make regex compatible with RHEL6 and RHEL7, aside from the existing compatibility with RHEL8 and RHEL9.